### PR TITLE
Add basin casting recipe for Starmetal Ore

### DIFF
--- a/scripts/astral.zs
+++ b/scripts/astral.zs
@@ -39,3 +39,6 @@ recipes.addShaped("astralwand", <astralsorcery:itemwand>.withTag({astralsorcery:
 	[<quark:marble_speleothem>, null, null]
 ]);
 
+// Astral Starmetal via tinkers construct so it doesn't require a floating crystal 
+mods.tconstruct.Casting.addBasinRecipe(<astralsorcery:blockcustomore:1>, <ore:oreIron>, <liquid:astralsorcery.liquidstarlight>, 1000, true, 100);
+mods.astralsorcery.LightTransmutation.removeTransmutation(<astralsorcery:blockcustomore:1>, false);


### PR DESCRIPTION
Fix #36, by adding a casting recipe for Starmetal Ore. **Requires #37 to be solved before.**

Starmetal Ore | ⠀
------- | --
![2021-07-10_11 03 29](https://user-images.githubusercontent.com/17405009/125158457-9b6b8100-e171-11eb-9448-9ad377d3f68a.png) | ⠀


See #38 for an alternative solution.