### PR TITLE
Spike: Make Nether void with Void Island Control mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 !config/Waystones.cfg
 !config/hats.cfg
 !config/lockdown.cfg
+!config/voidislandcontrol.cfg
 
 # advancements folder
 !advancements

--- a/config/voidislandcontrol.cfg
+++ b/config/voidislandcontrol.cfg
@@ -1,0 +1,337 @@
+# Configuration file
+
+general {
+
+    ##########################################################################################################
+    # worldgensettings
+    #--------------------------------------------------------------------------------------------------------#
+    # Config Settings for the world generation
+    ##########################################################################################################
+
+    worldgensettings {
+        # Dimension for island management to occur in
+        I:baseDimension=0
+
+        # Level where clouds appear
+        I:cloudLevel=32
+
+        # End dimension will be a void world
+        B:endVoid=false
+
+        # End dimension will generate structures (Only takes effect if end is a void world)
+        B:endVoidStructures=true
+
+        # Level where the horizon appears
+        I:horizonLevel=40
+
+        # Nether dimension will be a void world
+        B:netherVoid=true
+
+        # Nether dimension will generate structures (Only takes effect if nether is a void world)
+        B:netherVoidStructures=false
+
+        # Biome used for entire world
+        I:worldBiomeID=-1
+
+        # VOID-NOT USED, OVERWORLD-NOT USED, SUPERFLAT-Use the string as used for normal flat worlds, WORLDTYPE-world type to be used (set like server level-types), CUSTOMIZED-NOT USED
+        S:worldGenSpecialParameters=
+
+        # Overworld generation type
+        # Valid values:
+        # VOID
+        # OVERWORLD
+        # SUPERFLAT
+        # WORLDTYPE
+        # CUSTOMIZED
+        S:worldGenType=VOID
+    }
+
+    ##########################################################################################################
+    # islandsettings
+    #--------------------------------------------------------------------------------------------------------#
+    # Config Settings for the world generation
+    ##########################################################################################################
+
+    islandsettings {
+        # Allow players to create or reset their islands
+        B:allowIslandCreation=false
+
+        # Automatically give new players islands
+        B:autoCreate=false
+
+        # ONLY TAKES EFFECT ON DEDICATED SERVERS-Automatically give new players islands
+        B:autoCreateServersOnly=false
+
+        # Type of block to spawn under islands
+        # Valid values:
+        # BEDROCK
+        # SECONDARYBLOCK
+        S:bottomBlockType=BEDROCK
+
+        # Sets how long the buffs are given when spawning on an island in ticks (I think)
+        I:buffTimer=1200
+
+        # Custom islands using the structure block data. Files are to be placed in the voidislandcontrolstructures config folder. The names in this list should be the same as the structure names. These names are the ids for the island type as well
+        S:customIslands <
+         >
+
+        # Forces players to spawn at the spawn position. By default, the player will be teleported to a safe spot above it if spawning fails. This config disables that
+        B:forceSpawn=false
+
+        # Biome used for islands
+        I:islandBiomeID=-1
+
+        # Biome range (width) used for islands
+        I:islandBiomeRange=0
+
+        # Distance between islands
+        I:islandDistance=1000
+
+        # This is for the island at 0,0! Valids are random, bedrock, sand, snow, wood, grass, gog, or others added by addons/custom islands
+        S:islandMainSpawnType=bedrock
+
+        # Disables effect of protectionBuildRange
+        B:islandProtection=false
+
+        # Width of islands
+        I:islandSize=3
+
+        # Valids are random, sand, snow, wood, grass, gog, or others added by addons/custom islands
+        S:islandSpawnType=random
+
+        # Y Level to spawn islands at (Set to 2 above where you want the ground block)
+        I:islandYLevel=88
+
+        # Start the world in one chunk mode
+        B:oneChunk=false
+
+        # Range where players from other islands are not allowed and the range furthest players of an island can go. Affects spawn too (Max of islandDistance/2)
+        I:protectionBuildRange=500
+
+        # Reset players inventory with the starting inventory
+        B:resetInventory=false
+
+        # Spawn a chest on the island
+        B:spawnChest=false
+
+        # Protect spawn from building, destroying, interactions with blocks and machines, etc. Those in creative are ignored
+        B:spawnProtection=false
+
+        # Starting items given to new players. Use the /startingInv command in game
+        S:startingItems <
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+         >
+
+        ##########################################################################################################
+        # grasssettings
+        #--------------------------------------------------------------------------------------------------------#
+        # Settings for the grass island
+        ##########################################################################################################
+
+        grasssettings {
+            # Allow grass island to be used
+            B:enableGrassIsland=false
+
+            # Type of grass/dirt
+            # Valid values:
+            # GRASS
+            # DIRT
+            # COARSEDIRT
+            S:grassBlockType=GRASS
+
+            # Spawn a tree
+            B:spawnTree=false
+        }
+
+        ##########################################################################################################
+        # sandsettings
+        #--------------------------------------------------------------------------------------------------------#
+        # Settings for the sand island
+        ##########################################################################################################
+
+        sandsettings {
+            # Allow sand island to be used
+            B:enableSandIsland=false
+
+            # Type of sand
+            # Valid values:
+            # NORMAL
+            # RED
+            S:sandBlockType=RED
+
+            # Spawn a cactus
+            B:spawnCactus=false
+        }
+
+        ##########################################################################################################
+        # snowsettings
+        #--------------------------------------------------------------------------------------------------------#
+        # Settings for the snow island
+        ##########################################################################################################
+
+        snowsettings {
+            # Allow snow island to be used
+            B:enableSnowIsland=false
+
+            # Spawn an igloo
+            B:spawnIgloo=false
+
+            # Spawn pumpkins
+            B:spawnPumpkins=false
+        }
+
+        ##########################################################################################################
+        # woodsettings
+        #--------------------------------------------------------------------------------------------------------#
+        # Settings for the wood island
+        ##########################################################################################################
+
+        woodsettings {
+            # Allow wood island to be used
+            B:enableWoodIsland=false
+
+            # Spawn string
+            B:spawnString=false
+
+            # Spawn water
+            B:spawnWater=false
+
+            # Type of wood
+            # Valid values:
+            # OAK
+            # SPRUCE
+            # BIRCH
+            # JUNGLE
+            # ACACIA
+            # DARKOAK
+            S:woodBlockType=DARKOAK
+        }
+
+        ##########################################################################################################
+        # gogsettings
+        #--------------------------------------------------------------------------------------------------------#
+        # Settings for the Garden of Glass island (Requires Botania and Garden of Glass!)
+        ##########################################################################################################
+
+        gogsettings {
+            # Allow garden of glass island to be used
+            B:enableGoGIsland=false
+        }
+
+    }
+
+    ##########################################################################################################
+    # commandsettings
+    #--------------------------------------------------------------------------------------------------------#
+    # Config Settings for the world generation
+    ##########################################################################################################
+
+    commandsettings {
+        # Allows the home command to be used
+        B:allowHomeCommand=false
+
+        # Allows the visit command to be used
+        B:allowVisitCommand=false
+
+        # Run always or require redstone
+        B:commandBlockAuto=false
+
+        # Command for the command block to run
+        S:commandBlockCommand=
+
+        # Command Block direction to face
+        # Valid values:
+        # DOWN
+        # UP
+        # NORTH
+        # SOUTH
+        # WEST
+        # EAST
+        S:commandBlockDirection=UP
+
+        # Type of command block to spawn
+        # Valid values:
+        # NONE
+        # IMPULSE
+        # REPEATING
+        # CHAIN
+        S:commandBlockType=NONE
+
+        # Name of the main command
+        S:commandName=island
+
+        # Allow the one chunk command to be used
+        B:oneChunkCommandAllowed=false
+
+        # Commands to run when the world loads
+        S:worldLoadCommands <
+         >
+
+        ##########################################################################################################
+        # commandblockpos
+        #--------------------------------------------------------------------------------------------------------#
+        # Offset position for command block from the center block above the bedrock
+        ##########################################################################################################
+
+        commandblockpos {
+            # The x coordinate (Offset from the center block above the bedrock)
+            I:x=0
+
+            # The y coordinate (Offset from the center block above the bedrock)
+            I:y=0
+
+            # The z coordinate (Offset from the center block above the bedrock)
+            I:z=0
+        }
+
+    }
+
+    ##########################################################################################################
+    # othersettings
+    #--------------------------------------------------------------------------------------------------------#
+    # Config Settings for other stuff
+    ##########################################################################################################
+
+    othersettings {
+        # Hide the toasts when at spawn
+        B:hideToasts=false
+    }
+
+}
+
+


### PR DESCRIPTION
The [Void Island Control](https://www.curseforge.com/minecraft/mc-mods/void-island-control/files/2666967) mod is way to overpowered for just voiding the Nether. But it works.