### PR TITLE
Disable q button in main and pause menus

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -25,7 +25,7 @@ _global {
 
     # Set this to false to disable the q button in the main and pause menus.
     # If you disable this, you can still access the quark config from Mod Options > Quark > Config
-    B:"Enable q Button"=true
+    B:"Enable q Button"=false
 
     # Note that if you turn off 'Use Piston Logic Replacement', this value will not apply.
     I:"Piston Push Limit"=12


### PR DESCRIPTION
As @voruti mentioned on discord: 

> Ich schaue mir gerade den diff zwischen CraftBlock-1.0.0.zip und CraftBlock-v1.1.0.zip an:
> ![](https://media.discordapp.net/attachments/863757608381186088/883048663864189008/unknown.png)

This change between pre-release v1.0.0 and release candidate v1.1.0 was caused by #52 for which I generated a new, default config.
It was unintended and therefore should be reverted. 
Also the  button isn't very usefull from my pov.