### PR TITLE
Fix Malformed list property in quark.cfg:1400

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -1397,7 +1397,7 @@ tweaks {
 
         # Which crops can be harvested?
         # Format is: "harvestState[,afterHarvest]", i.e. "minecraft:wheat:7" or "minecraft:cocoa:11,minecraft:cocoa:3"
-        S:"Harvestable Crops" <            
+        S:"Harvestable Crops" <
             harvestcraft:pamagavecrop:3
             harvestcraft:pamamaranthcrop:3
             harvestcraft:pamarrowrootcrop:3


### PR DESCRIPTION
#52 was tested and worked but then before committing some spaces seemed to sneak in and broke everything. 😅 

This resulted in a broken config and some errors:
```
[10:23:11] [Client thread/FATAL] [FML]: An exception occurred while loading config file quark.cfg. This file will be renamed to quark.cfg_20210903_102311.errored and a new config file will be generated.
java.lang.RuntimeException: Malformed list property "D:/MultiMC/instances/SkyblockNachfolger_dev/.minecraft/config/quark.cfg:1400"
	at net.minecraftforge.common.config.Configuration.load(Configuration.java:1000) ~[Configuration.class:?]
	at net.minecraftforge.common.config.Configuration.runConfiguration(Configuration.java:129) [Configuration.class:?]
	at net.minecraftforge.common.config.Configuration.<init>(Configuration.java:146) [Configuration.class:?]
	at net.minecraftforge.common.config.Configuration.<init>(Configuration.java:107) [Configuration.class:?]
	at vazkii.quark.base.module.ModuleLoader.setupConfig(ModuleLoader.java:146) [ModuleLoader.class:?]
	at vazkii.quark.base.module.ModuleLoader.preInit(ModuleLoader.java:100) [ModuleLoader.class:?]
	at vazkii.quark.base.proxy.CommonProxy.preInit(CommonProxy.java:34) [CommonProxy.class:?]
	at vazkii.quark.base.proxy.ClientProxy.preInit(ClientProxy.java:47) [ClientProxy.class:?]
	at vazkii.quark.base.Quark.preInit(Quark.java:44) [Quark.class:?]

	...
```

Thanks to @voruti for unintentionally making me aware of it by posting this diff on discord:

![](https://media.discordapp.net/attachments/863757608381186088/883049868229238824/unknown.png)