### PR TITLE
Tweak recipes for Red Sand and Terracotta

### DIFF
--- a/scripts/vanilla.zs
+++ b/scripts/vanilla.zs
@@ -5,6 +5,12 @@ mods.botania.ManaInfusion.removeRecipe(<minecraft:sand>);
 mods.botania.ManaInfusion.addAlchemy(<minecraft:gravel>, <minecraft:cobblestone>, 50);
 mods.botania.ManaInfusion.addAlchemy(<minecraft:sand>, <minecraft:gravel>, 50);
 
+//Red Sand & Terracotta
+mods.tconstruct.Casting.removeBasinRecipe(<minecraft:sand:1>);
+mods.tconstruct.Casting.addBasinRecipe(<minecraft:sand:1>, <minecraft:sand:0>, <liquid:blood>, 5, true, 20);
+mods.botania.ManaInfusion.removeRecipe(<minecraft:hardened_clay>);
+mods.botania.ManaInfusion.addAlchemy(<minecraft:hardened_clay>, <minecraft:sand:1>, 50);
+
 // podzol -> mycelium
 mods.astralsorcery.LightTransmutation.addTransmutation(<minecraft:dirt:2>, <minecraft:mycelium>, 20);
 


### PR DESCRIPTION
Red Sand and Terracotta are currently quite grindy to get, which is annoying as Terracotta is a great building block and Red Sand can be used to create Redstone timers with the Hovering Hourglass (10s delay per sand, max 1Stack eg. 6min40s delay).
This is due to the insane time starlight transmutation of clay takes and the annoyance of filling a Smeltery with enough blood.

This PR does the following small changes to remove the issue:
1. Half the blood cost of creating Red Sand from Sand in the Smeltery so 1 Heart ≙ 4 Red Sand
2. Mirror the Mana Infusion recipe so Terracotta can be crafted from Red Sand

There are no other recipes that would be significantly cheaper with this change.