### PR TITLE
Slightly improve warp stone recipe

### DIFF
--- a/scripts/waystone.zs
+++ b/scripts/waystone.zs
@@ -2,7 +2,7 @@
 
 val eversioShiftingStar = <astralsorcery:itemshiftingstar>.withTag({
 	astralsorcery:{
-		starAttunement: "astralsorcery.constellation.evorsio"
+		starAttunement: "astralsorcery.constellation.vicio"
 	}
 });
 recipes.remove(<waystones:warp_stone>);


### PR DESCRIPTION
When creating sebinside#33 i did choose to use the Eversio Irradiant Star for crafting the Warp Stone due too it's similar colour.

Having worked a little bit more with Astral Sorcery I now find that the Vicio Irradiant Star would fit way better as the Vicio constellation is a symbol for motion while Eversio is for destruction.

The recipe would not get more difficult by this change but it would make more sense.