### PR TITLE
Rituals

### DIFF
--- a/config/astralsorcery.cfg
+++ b/config/astralsorcery.cfg
@@ -604,10 +604,10 @@ ritual_effects {
         B:vicioEnabled=true
 
         # Defines the radius (in blocks) in which the ritual will allow the players to fly in. [range: 1.0 ~ 512.0, default: 24.0]
-        S:vicioRange=24.0
+        S:vicioRange=16.0
 
         # Defines the increase in radius the ritual will get per active lens enhancing the ritual. [range: 1 ~ 128, default: 16]
-        I:vicioRangeIncreasePerLens=16
+        I:vicioRangeIncreasePerLens=8
     }
 
     evorsio {

--- a/scripts/astral.zs
+++ b/scripts/astral.zs
@@ -39,3 +39,21 @@ recipes.addShaped("astralwand", <astralsorcery:itemwand>.withTag({astralsorcery:
 	[<quark:marble_speleothem>, null, null]
 ]);
 
+
+// Insane recipe for Ritual Pedestal
+mods.astralsorcery.Altar.removeAltarRecipe("astralsorcery:shaped/internal/altar/ritualpedestal");
+mods.astralsorcery.Altar.addTraitAltarRecipe("astralsorcery:shaped/internal/altar/ritualpedestal", <astralsorcery:blockritualpedestal>, 4500, 200, [
+
+    <astralsorcery:blockmarble:4>, <astralsorcery:blockcelestialcollectorcrystal>.withTag({astralsorcery:{collectorType:1}}), <astralsorcery:blockmarble:4>,
+    <astralsorcery:blockmarble:2>, <liquid:astralsorcery.liquidstarlight>, <astralsorcery:blockmarble:2>,
+    <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>,
+    
+    <ore:ingotGold>, <ore:ingotGold>, <astralsorcery:blockmarble:2>, <astralsorcery:blockmarble:2>,
+    null, null, null, null, 
+    null, null, null, null,
+    null, null, null, null,
+    
+    //Outer Items, indices 25+
+    <uniquecrops:oldgold>, <ore:eternalLifeEssence>, <ore:dustDiamond>, <hwell:loot_enderman>
+
+], "astralsorcery.constellation.horologium");


### PR DESCRIPTION
Rituals are overpowered, see: https://www.youtube.com/watch?v=4a5GhyihDFI

Especially the Vicio Ritual which provides creative flight inside the range of the ritual.

This tries to nerve it by making the Ritual Pedestal insanely difficult and reducing the range of Vicio from 24-104 blocks to 16-56 Blocks.

The new crafting recipe requires playing through Astral Sorcery, Botania, Hearthwell, Unique Crops and Immersive Engineering until the Crusher:

![Unbenannt](https://user-images.githubusercontent.com/17405009/132896431-3be3b71c-84df-401d-8fcf-29abc8bf3bfc.png)

_The [Horologium](https://ftb.fandom.com/wiki/Horologium) constellation, which needs to be attuned to a crystal for this altar recipe, only occurs once in 12h of playtime._

Close #66 