### PR TITLE
Tree Beacon

### DIFF
--- a/scripts/astral.zs
+++ b/scripts/astral.zs
@@ -39,3 +39,16 @@ recipes.addShaped("astralwand", <astralsorcery:itemwand>.withTag({astralsorcery:
 	[<quark:marble_speleothem>, null, null]
 ]);
 
+// Nerved Tree Beacon with Botania mixed in
+mods.astralsorcery.Altar.removeAltarRecipe("astralsorcery:shaped/internal/altar/treebeacon");
+mods.astralsorcery.Altar.addConstellationAltarRecipe("mypackname:shaped/internal/altar/treebeacon", <astralsorcery:blocktreebeacon>, 2500, 500, [
+    <ore:treeLeaves>, <astralsorcery:itemcraftingcomponent:4>, <ore:treeLeaves>,
+    <botania:lens:18>, <liquid:astralsorcery.liquidstarlight>, <botania:lens:7>,
+    <astralsorcery:blockinfusedwood>, <botania:storage:1>, <astralsorcery:blockinfusedwood>,
+
+    <botania:specialflower>.withTag({type: "agricarnation"}), <botania:specialflower>.withTag({type: "hopperhock"}),
+    <botania:specialflower>.withTag({type: "rannuncarpus"}), <botania:specialflower>.withTag({type: "agricarnation"}),
+
+    <ore:treeLeaves>, <ore:treeLeaves>, <ore:treeLeaves>, <ore:treeLeaves>,
+    <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>
+]);


### PR DESCRIPTION
The Tree Beacon is a automatic tree farm, see: https://youtu.be/1egFpakoWro?t=873

It is not very balanced as [Botania Tree Farms](https://www.youtube.com/watch?v=cdesWFyK7TQ) are more expensive and more difficult to create.

This PR tries to change it by depending the recipe on the Flowers & Items that would be required for a Botania Tree Farm, 
so the choice is up to the player which one he prefers.

The new recipe:

![](https://user-images.githubusercontent.com/17405009/132942501-1b59eb58-428a-4dca-93b2-cca2c7e164e1.png)

Close #66