### PR TITLE
Dispensers may also place modded seeds

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -166,6 +166,120 @@ automation {
     "dispensers place seeds" {
         # Add seeds from other mods here, in the following format: mod:seed=mod:block:meta. Set meta to -1 to just place the default.
         S:"Custom Seeds" <
+            uniquecrops:seedartisia=uniquecrops:cropartisia:0
+            uniquecrops:seedknowledge=uniquecrops:cropknowledge:0
+            uniquecrops:seeddevilsnare=uniquecrops:cropdevilsnare:0
+            uniquecrops:seedindustria=uniquecrops:cropindustria:0
+            uniquecrops:seedhexis=uniquecrops:crophexis:0
+            uniquecrops:seedlacusia=uniquecrops:croplacusia:0
+            uniquecrops:seedpixelsius=uniquecrops:croppixelsius:0
+            uniquecrops:seedferoxia=uniquecrops:cropferoxia:0
+            uniquecrops:seeddirigible=uniquecrops:cropdirigible:0
+            uniquecrops:seeddyeius=uniquecrops:cropdyeius:0
+            uniquecrops:seedmusica=uniquecrops:cropmusica:0
+            uniquecrops:seedprecision=uniquecrops:cropprecision:0
+            uniquecrops:seedinvisibilia=uniquecrops:cropinvisibilia:0
+            uniquecrops:seedmaryjane=uniquecrops:cropmaryjane:0
+            uniquecrops:seedenderlily=uniquecrops:cropenderlily:0
+            uniquecrops:seednormal=uniquecrops:cropnormal:0
+            uniquecrops:seedmerlinia=uniquecrops:cropmerlinia:0
+            uniquecrops:seedimperia=uniquecrops:cropimperia:0
+            uniquecrops:seedsucco=uniquecrops:cropsucco:0
+            uniquecrops:seedinstabilis=uniquecrops:cropinstabilis:0
+            uniquecrops:seedcobblonia=uniquecrops:cropcobblonia:0
+            uniquecrops:seeddonutsteel=uniquecrops:cropdonutsteel:0
+            uniquecrops:seedweepingbells=uniquecrops:cropweepingbells:0
+            uniquecrops:seedcollis=uniquecrops:cropcollis:0
+            uniquecrops:seedcinderbella=uniquecrops:cropcinderbella:0
+            uniquecrops:seedmagnes=uniquecrops:cropmagnes:0
+            uniquecrops:seedpetramia=uniquecrops:croppetramia:0
+            uniquecrops:seedmillennium=uniquecrops:cropmillennium:0
+            uniquecrops:seedwafflonia=uniquecrops:cropwafflonia:0
+            uniquecrops:seedmalleatoris=uniquecrops:cropmalleatoris:0
+            uniquecrops:seedholy=uniquecrops:cropholy:0
+            harvestcraft:agaveseeditem=harvestcraft:pamagavecrop:0
+            harvestcraft:amaranthseeditem=harvestcraft:pamamaranthcrop:0
+            harvestcraft:arrowrootseeditem=harvestcraft:pamarrowrootcrop:0
+            harvestcraft:artichokeseeditem=harvestcraft:pamartichokecrop:0
+            harvestcraft:asparagusseeditem=harvestcraft:pamasparaguscrop:0
+            harvestcraft:bambooshootseeditem=harvestcraft:pambambooshootcrop:0
+            harvestcraft:barleyseeditem=harvestcraft:pambarleycrop:0
+            harvestcraft:beanseeditem=harvestcraft:pambeancrop:0
+            harvestcraft:beetseeditem=harvestcraft:pambeetcrop:0
+            harvestcraft:bellpepperseeditem=harvestcraft:pambellpeppercrop:0
+            harvestcraft:blackberryseeditem=harvestcraft:pamblackberrycrop:0
+            harvestcraft:blueberryseeditem=harvestcraft:pamblueberrycrop:0
+            harvestcraft:broccoliseeditem=harvestcraft:pambroccolicrop:0
+            harvestcraft:brusselsproutseeditem=harvestcraft:pambrusselsproutcrop:0
+            harvestcraft:cabbageseeditem=harvestcraft:pamcabbagecrop:0
+            harvestcraft:cactusfruitseeditem=harvestcraft:pamcactusfruitcrop:0
+            harvestcraft:candleberryseeditem=harvestcraft:pamcandleberrycrop:0
+            harvestcraft:cantaloupeseeditem=harvestcraft:pamcantaloupecrop:0
+            harvestcraft:cassavaseeditem=harvestcraft:pamcassavacrop:0
+            harvestcraft:cauliflowerseeditem=harvestcraft:pamcauliflowercrop:0
+            harvestcraft:celeryseeditem=harvestcraft:pamcelerycrop:0
+            harvestcraft:chickpeaseeditem=harvestcraft:pamchickpeacrop:0
+            harvestcraft:chilipepperseeditem=harvestcraft:pamchilipeppercrop:0
+            harvestcraft:coffeebeanseeditem=harvestcraft:pamcoffeebeancrop:0
+            harvestcraft:cornseeditem=harvestcraft:pamcorncrop:0
+            harvestcraft:cottonseeditem=harvestcraft:pamcottoncrop:0
+            harvestcraft:cranberryseeditem=harvestcraft:pamcranberrycrop:0
+            harvestcraft:cucumberseeditem=harvestcraft:pamcucumbercrop:0
+            harvestcraft:curryleafseeditem=harvestcraft:pamcurryleafcrop:0
+            harvestcraft:eggplantseeditem=harvestcraft:pameggplantcrop:0
+            harvestcraft:elderberryseeditem=harvestcraft:pamelderberrycrop:0
+            harvestcraft:flaxseeditem=harvestcraft:pamflaxcrop:0
+            harvestcraft:garlicseeditem=harvestcraft:pamgarliccrop:0
+            harvestcraft:gigapickleseeditem=harvestcraft:pamgigapicklecrop:0
+            harvestcraft:gingerseeditem=harvestcraft:pamgingercrop:0
+            harvestcraft:grapeseeditem=harvestcraft:pamgrapecrop:0
+            harvestcraft:greengrapeseeditem=harvestcraft:pamgreengrapecrop:0
+            harvestcraft:huckleberryseeditem=harvestcraft:pamhuckleberrycrop:0
+            harvestcraft:jicamaseeditem=harvestcraft:pamjicamacrop:0
+            harvestcraft:juniperberryseeditem=harvestcraft:pamjuniperberrycrop:0
+            harvestcraft:juteseeditem=harvestcraft:pamjutecrop:0
+            harvestcraft:kaleseeditem=harvestcraft:pamkalecrop:0
+            harvestcraft:kenafseeditem=harvestcraft:pamkenafcrop:0
+            harvestcraft:kiwiseeditem=harvestcraft:pamkiwicrop:0
+            harvestcraft:kohlrabiseeditem=harvestcraft:pamkohlrabicrop:0
+            harvestcraft:leekseeditem=harvestcraft:pamleekcrop:0
+            harvestcraft:lentilseeditem=harvestcraft:pamlentilcrop:0
+            harvestcraft:lettuceseeditem=harvestcraft:pamlettucecrop:0
+            harvestcraft:milletseeditem=harvestcraft:pammilletcrop:0
+            harvestcraft:mulberryseeditem=harvestcraft:pammulberrycrop:0
+            harvestcraft:mustardseedsseeditem=harvestcraft:pammustardseedscrop:0
+            harvestcraft:oatsseeditem=harvestcraft:pamoatscrop:0
+            harvestcraft:okraseeditem=harvestcraft:pamokracrop:0
+            harvestcraft:onionseeditem=harvestcraft:pamonioncrop:0
+            harvestcraft:parsnipseeditem=harvestcraft:pamparsnipcrop:0
+            harvestcraft:peanutseeditem=harvestcraft:pampeanutcrop:0
+            harvestcraft:peasseeditem=harvestcraft:pampeascrop:0
+            harvestcraft:pineappleseeditem=harvestcraft:pampineapplecrop:0
+            harvestcraft:quinoaseeditem=harvestcraft:pamquinoacrop:0
+            harvestcraft:radishseeditem=harvestcraft:pamradishcrop:0
+            harvestcraft:raspberryseeditem=harvestcraft:pamraspberrycrop:0
+            harvestcraft:rhubarbseeditem=harvestcraft:pamrhubarbcrop:0
+            harvestcraft:riceseeditem=harvestcraft:pamricecrop:0
+            harvestcraft:rutabagaseeditem=harvestcraft:pamrutabagacrop:0
+            harvestcraft:ryeseeditem=harvestcraft:pamryecrop:0
+            harvestcraft:scallionseeditem=harvestcraft:pamscallioncrop:0
+            harvestcraft:seaweedseeditem=harvestcraft:pamseaweedcrop:0
+            harvestcraft:sesameseedsseeditem=harvestcraft:pamsesameseedscrop:0
+            harvestcraft:sisalseeditem=harvestcraft:pamsisalcrop:0
+            harvestcraft:soybeanseeditem=harvestcraft:pamsoybeancrop:0
+            harvestcraft:spiceleafseeditem=harvestcraft:pamspiceleafcrop:0
+            harvestcraft:spinachseeditem=harvestcraft:pamspinachcrop:0
+            harvestcraft:strawberryseeditem=harvestcraft:pamstrawberrycrop:0
+            harvestcraft:sweetpotatoseeditem=harvestcraft:pamsweetpotatocrop:0
+            harvestcraft:taroseeditem=harvestcraft:pamtarocrop:0
+            harvestcraft:tealeafseeditem=harvestcraft:pamtealeafcrop:0
+            harvestcraft:tomatilloseeditem=harvestcraft:pamtomatillocrop:0
+            harvestcraft:tomatoseeditem=harvestcraft:pamtomatocrop:0
+            harvestcraft:turnipseeditem=harvestcraft:pamturnipcrop:0
+            harvestcraft:waterchestnutseeditem=harvestcraft:pamwaterchestnutcrop:0
+            harvestcraft:whitemushroomseeditem=harvestcraft:pamwhitemushroomcrop:0
+            harvestcraft:wintersquashseeditem=harvestcraft:pamwintersquashcrop:0
+            harvestcraft:zucchiniseeditem=harvestcraft:pamzucchinicrop:0
          >
 
         # This feature disables itself if any of the following mods are loaded: 
@@ -173,7 +287,7 @@ automation {
         #  - animania
         # This is done to prevent content overlap.
         # You can turn this on to force the feature to be loaded even if the above mods are also loaded.
-        B:"Force Enabled"=false
+        B:"Force Enabled"=true
     }
 
 }


### PR DESCRIPTION
Botania and Quark allow the use of dispensers to place seeds. 

Unfortunately this only works with vanilla crops so there is currently no automatic way to place seeds from Harvestcraft or Unique Crops (the Setter from Hearthwell doesn't work with seeds).

This PR adds all seeds from Pams Harvestcraft and Unique Crops to the Quark config file.