### PR TITLE
Remove Hearthwell Seeds

### DIFF
--- a/scripts/hearthwell.zs
+++ b/scripts/hearthwell.zs
@@ -47,6 +47,16 @@ for item in coreList {
 // Disable heat core crafting
 moretweaker.hwell.MoreCoring.removeCoring("core_heat", null);
 
+// Disable Seeds 
+val seeds = [
+    <hwell:seed_of_life>,
+    <hwell:seed_of_the_nether>,
+    <hwell:seed_of_the_end>
+] as IItemStack[];
+for item in seeds {
+    disable(item);
+}
+
 // Add new metaldiamond recipe
 mods.tconstruct.Casting.addTableRecipe(<hwell:metaldiamond>, <ore:manaDiamond>, <liquid:astral_starmetal>, 144, true);
 


### PR DESCRIPTION
Hearthwell has seeds that when placed transform the surrounding to a specific setting in a small radius:

![2021-09-13_10 24 48](https://user-images.githubusercontent.com/17405009/133050972-934b78fb-62d3-4c77-a054-da49cdbd695e.png)
 
I think the Nether- and End Seeds break the balancing as they provide easy ways to aquire a lot of materials that the player should normally have no access to that early.

The Seed of Life is just useless.

See https://github.com/sebinside/CraftBlock/issues/71#issuecomment-917723859