### PR TITLE
Caminite output increased to 3

### DIFF
--- a/scripts/embers.zs
+++ b/scripts/embers.zs
@@ -52,7 +52,7 @@ recipes.addShaped("emberActivator", <embers:ember_activator>, [
 
 // Two new caminite recipes
 recipes.remove(<embers:blend_caminite>);
-recipes.addShapeless("caminiteHard", <embers:blend_caminite>, [<minecraft:clay_ball>, <minecraft:clay_ball>, <ore:itemSlag>, <ore:itemSlag>, <minecraft:sand>]);
+recipes.addShapeless("caminiteHard", <embers:blend_caminite> * 3, [<minecraft:clay_ball>, <minecraft:clay_ball>, <ore:itemSlag>, <ore:itemSlag>, <minecraft:sand>]);
 
 mods.embers.Melter.add(<liquid:clay> * 144, <ore:clay>);
 mods.embers.Stamper.add(<embers:blend_caminite> * 4, <liquid:clay> * 144, <embers:stamp_flat>, <ore:sand>);


### PR DESCRIPTION
Obtaining caminite through slack was a really grindy task.  

To create an Ember Bore, a Stamper and power the Stamper using an Ember Activator you need at least `70` Caminite Blend.  
With the old recipe you needed `2` Slack for each blend (`140` Slack total) and each Slack takes roughly a minute to produce.
After all you were waiting over two hours for the furnace to finish.   

The new recipe cuts this time down to `~48min` which is still nerve-wracking but a less horrible experience.

### New Recipe:
![grafik](https://user-images.githubusercontent.com/17405009/133421380-505b67be-3efd-40e1-978d-d088b7454e03.png)
