### PR TITLE
🌈 Mutator dye recipe

### DIFF
--- a/scripts/hearthwell.zs
+++ b/scripts/hearthwell.zs
@@ -69,6 +69,14 @@ recipes.addShaped("mutator", <hwell:mutator>, [
 ]);
 recipes.addShapeless("mutationpaste", <hwell:mutation_paste> * 2, [<harvestcraft:mixingbowlitem>, <ore:slimeball>, <botania:dye:*>, <botania:dye:*>, <botania:dye:*>, <botania:dye:*>]);
 
+//Additional mutation recepies
+mods.hwell.addMutationPasteRecipe([
+    <minecraft:dye:6>,  <minecraft:dye:4>,  <minecraft:dye:5>, <minecraft:dye:13>,
+    <minecraft:dye:9>,  <minecraft:dye:15>, <minecraft:dye:7>, <minecraft:dye:8>,
+    <minecraft:dye:0>,  <minecraft:dye:3>,  <minecraft:dye:1>, <minecraft:dye:14>,
+    <minecraft:dye:11>, <minecraft:dye:10>, <minecraft:dye:2>, <minecraft:dye:12>
+]);
+
 // Remove light crushing to glowstone
 mods.hwell.removeCrushingBlockRecipe(<hwell:locked_light>);
 


### PR DESCRIPTION
This PR adds some more nice and lovely rainbow to the modpack. 🌈🌈🌈
Who could say no to that? 

The other side effect is providing an easier way to get the vanilla dyes. At the point in the game where the mutator can be crafted all colours are easily available as Botania Floral Dye Powder but some mods such as Bibliocraft don't support the use of floral powder in their recipes.  
This finally makes the mutator a useful block.

Clever players could abuse this mechanic to obtain some Lapis. But let's be honest: At this point in the game a player can just dupe Red- & Glowstone in the Mana Pool so crafting Lapis out of Bone Meal or Red Dye does not break the balancing.  
I made abusing this as annoying as possible by requiring many steps of mutation before reaching lapis from any of the more common materials.

### New Recipe:
![grafik](https://user-images.githubusercontent.com/17405009/133450194-53f0b74b-a358-4f0b-b35b-4da2a2d233cb.png)
