### PR TITLE
Add ink recipe

### DIFF
--- a/scripts/_oredict.zs
+++ b/scripts/_oredict.zs
@@ -1,0 +1,26 @@
+import crafttweaker.item.IItemStack;
+
+//sword
+<ore:sword>.addItems([
+    <minecraft:iron_sword:*>,
+    <minecraft:wooden_sword:*>,
+    <minecraft:stone_sword:*>,
+    <minecraft:diamond_sword:*>,
+    <minecraft:golden_sword:*>,
+    <botania:manasteelsword:*>,
+    <botania:elementiumsword:*>,
+    <botania:terrasword:*>,
+    <botania:starsword:*>,
+    <botania:thundersword:*>,
+    <hwell:mystic_iron_sword:*>,
+    <hwell:soulsteel_sword:*>,
+    <immersiveengineering:sword_steel:*>,
+    <embers:sword_dawnstone:*>,
+    <uniquecrops:precision.sword:*>,
+    <astralsorcery:itemcrystalsword:*>,
+    <astralsorcery:itemchargedcrystalsword:*>,
+    <tconstruct:broadsword:*>,
+    <tconstruct:longsword:*>,
+    <tconstruct:rapier:*>,
+    <tconstruct:cleaver:*>
+]);

--- a/scripts/vanilla.zs
+++ b/scripts/vanilla.zs
@@ -129,3 +129,6 @@ recipes.addShaped("enchantment_table", <minecraft:enchanting_table>,[
 	[<tconstruct:materials:16>, <ore:obsidian>, <tconstruct:materials:16>], 
 	[<ore:obsidian>, <tconstruct:materials:14>, <ore:obsidian>]
 ]);
+
+//octopus ink
+recipes.addShapeless("ink", <minecraft:dye>, [<ore:foodOctopusraw>, <ore:sword>.transformDamage(10)]);


### PR DESCRIPTION
As no Ocean Biomes generate on the map currently the only way to get ink sacks is fishing.  
But this is not documented and it's only a very rare drop.  
So to make this process a bit less grindy I propose a crafting recipe for ink:

![grafik](https://user-images.githubusercontent.com/17405009/138443830-fbf33a3d-4846-4e89-b9ca-cf93425c3d49.png)

Any sword (even damaged) can be used but they will take 10 damge per crafted ink sack so vanilla swords will be consumed. 