### PR TITLE
New Elite Crafting Table recipe

### DIFF
--- a/scripts/crops.zs
+++ b/scripts/crops.zs
@@ -2,6 +2,9 @@
 recipes.remove(<uniquecrops:seedartisia>);
 mods.botania.Apothecary.addRecipe(<uniquecrops:seedartisia>, [<uniquecrops:seednormal>, <uniquecrops:seednormal>, <uniquecrops:seednormal>, <uniquecrops:seednormal>, <minecraft:crafting_table>]);
 
+// Add description for vampiric ointment
+moretweaker.jei.MoreJei.addDescription(<uniquecrops:vampiric_ointment>, ["Obtained from Succo plants."]);
+
 // Add note to essence
 moretweaker.jei.MoreJei.addDescription(<uniquecrops:generic:9>, ["Dropped from Feroxia crops."]);
 

--- a/scripts/embers.zs
+++ b/scripts/embers.zs
@@ -5,6 +5,9 @@ import crafttweaker.item.IItemStack;
 moretweaker.cfb.KitchenAppliances.addToasterRecipe(<embers:dust_ash>, <ore:foodToast>);
 moretweaker.jei.MoreJei.addDescription(<embers:dust_ash>, ["Ever wondered what happens if you toast a toast?"]);
 
+// Add description for alchemical waste
+moretweaker.jei.MoreJei.addDescription(<embers:alchemic_waste>, ["If you fail an Embers alchemy recipe, this is the result."]);
+
 // Remove embers' electrum
 val electrumItems = [
     <embers:ingot_electrum>,

--- a/scripts/extended.zs
+++ b/scripts/extended.zs
@@ -17,8 +17,17 @@ recipes.addShaped("extendedcrafting_table_advanced", <extendedcrafting:table_adv
     [null, <embers:ashen_stone>, null]
 ]);
 
-// Remove Tier 3 and 4 crafting recipes just for now
+// New elite crafting table recipe
 recipes.remove(<extendedcrafting:table_elite>);
+mods.extendedcrafting.TableCrafting.addShaped(0, <extendedcrafting:table_elite>, [
+	[<quark:duskbound_lantern>, <ore:blockBlackIron>, <refinedstorage:machine_casing>, <ore:blockBlackIron>, <quark:duskbound_lantern>], 
+	[<ore:blockBlackIron>, <botania:lens:8>, <waystones:warp_stone>, <astralsorcery:itemcoloredlens:5>, <ore:blockBlackIron>], 
+	[<embers:caster_orb>, <uniquecrops:vampiric_ointment>, <minecraft:beacon>, <ore:record>, <embers:codex>], 
+	[<ore:blockBlackIron>, <embers:dawnstone_anvil>, <embers:alchemic_waste>, <refinedstorage:storage_part:2>, <ore:blockBlackIron>], 
+	[<quark:duskbound_lantern>, <ore:blockBlackIron>, <refinedstorage:machine_casing>, <ore:blockBlackIron>, <quark:duskbound_lantern>]
+]);
+
+// Remove Tier 4 crafting recipe just for now
 recipes.remove(<extendedcrafting:table_ultimate>);
 
 // Way better luminessence recipe

--- a/scripts/vanilla.zs
+++ b/scripts/vanilla.zs
@@ -132,3 +132,9 @@ recipes.addShaped("enchantment_table", <minecraft:enchanting_table>,[
 
 //octopus ink
 recipes.addShapeless("ink", <minecraft:dye>, [<ore:foodOctopusraw>, <ore:sword>.transformDamage(10)]);
+
+// Add description for music discs
+moretweaker.jei.MoreJei.addDescription(<ore:record>, ["Obtained from Musical Plant crops."]);
+
+// Add note to nether star
+moretweaker.jei.MoreJei.addDescription(<minecraft:nether_star>, ["Kill a Wither.", "Come on, it's really not hard, right?"]);


### PR DESCRIPTION
# Elite Crafting Table

<img width="500" alt="Elite Crafting Table recipe" src="https://user-images.githubusercontent.com/77919345/140169490-167a7b15-b9b2-437b-9d5c-c7f0ca2bda61.png">

I believe that this recipe has an appropriate level of complexity but is not too hard to craft nontheless.
I've also used some more of Unique Crops' plants as well as magic (Botania & Astral Sorcery) and tech (Embers & Refined Storage) related items to add more variety and mod balance to it.

<br>

List of changes:
- Added a crafting recipe for the Elite Crafting Table
- Added obtainment descriptions to
  - Vampiric Ointment
  - Music Disc
  - Alchemical Waste
  - Nether Star