### PR TITLE
Disable mantle flight perk

### DIFF
--- a/scripts/astral.zs
+++ b/scripts/astral.zs
@@ -70,3 +70,6 @@ mods.astralsorcery.Altar.addConstellationAltarRecipe("mypackname:shaped/internal
     <ore:treeLeaves>, <ore:treeLeaves>, <ore:treeLeaves>, <ore:treeLeaves>,
     <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>, <astralsorcery:blockmarble:6>
 ]);
+
+//disable overpowered perks
+mods.astralsorcery.PerkTree.disablePerk("astralsorcery:key_mantle_flight");


### PR DESCRIPTION
Related to #62.

The perk did grant creative flight with vicio mantle of the stars, so I disabled it.

|  Previous | Now | 
|------------|------------ |
|![grafik](https://user-images.githubusercontent.com/17405009/143766923-c971ad35-4da2-42c8-a2c2-21a4bfa27d26.png) | ![grafik](https://user-images.githubusercontent.com/17405009/143766948-db8db45c-9e8e-43ed-8257-82f61ba832de.png) |

❤ RGBPixl 😉 