### PR TITLE
Made Cropworld dimension accessible

### DIFF
--- a/scripts/crops.zs
+++ b/scripts/crops.zs
@@ -50,7 +50,22 @@ for item in baubles {
     disable(item);
 }
 
+// Ruined Bricks recipe for cropworld portal
+recipes.addShaped(<uniquecrops:ruinedbricks> * 8, [
+    [<tconstruct:brownstone:10>, <embers:wildfire_core>, <tconstruct:brownstone:10>],
+    [<uniquecrops:generic:17>, <botania:alfheimportal>, <uniquecrops:generic:17>],
+    [<tconstruct:brownstone:10>, <embers:wildfire_core>, <tconstruct:brownstone:10>]
+]);
+recipes.addShaped(<uniquecrops:ruinedbrickscarved> * 4, [
+    [<uniquecrops:ruinedbricks>, <uniquecrops:ruinedbricks>],
+    [<uniquecrops:ruinedbricks>, <uniquecrops:ruinedbricks>]
+]);
+recipes.addShapeless(<uniquecrops:ruinedbricks>, [<uniquecrops:ruinedbrickscarved>]);
+
 // Add notes for beginners
 moretweaker.jei.MoreJei.addDescription(<uniquecrops:generic:11>, ["Dropped from Invisibilia crops."]);
 moretweaker.jei.MoreJei.addDescription(<uniquecrops:seednormal>, ["Dropped from breaking grass."]);
 moretweaker.jei.MoreJei.addDescription(<uniquecrops:seedferoxia>, ["Might be a good idea to backup those..."]);
+moretweaker.jei.MoreJei.addDescription(<uniquecrops:flywood_sapling>, ["Can only be found in the Cropworld Dimension."]);
+moretweaker.jei.MoreJei.addDescription(<uniquecrops:useless_lump>, ["Made with the Cocito.", "Seems it's not that useless anyway..."]);
+moretweaker.jei.MoreJei.addDescription(<uniquecrops:generic:30>, ["Play now! On the new §2Itero Supercrop§r!"]);


### PR DESCRIPTION
<h2>What is the Cropworld</h2>

The Cropworld is a dimension added by Unique Crops. Basically it's just an infinite jump'n'run map with normal dungeon-like chest loot as reward. Flying and usage of items as well as breaking blocks in this dimension is impossible, so even if the Flügel Tiara or Mantle of Stars were brought there, they could not be used. Falling into the void of this dimension will teleport the player back to the overworld, punishing any failure. The portal to this dimension is made from Ruined Bricks normally found deep underground, thus making it impossible to build in skyblock. 16 of them are needed for building the portal, in addition to an emerald block that will be consumed upon completing assembly. A Wildwood Staff with 50 or more crop power will cause the portal to open.

![2022-04-01_20 29 04](https://user-images.githubusercontent.com/77919345/161322225-d2d1dfd8-da75-4839-b9e7-299aba0206c5.png)


<h2>Changes Made</h2>

- Added a medium-difficulty recipe for the normal and carved variants of Ruined Bricks. 
- Added some tips for other UC items as well
<br>

<img width="250" alt="image" src="https://user-images.githubusercontent.com/77919345/161321529-c7a111e0-9a61-4038-a3b2-0b999bad4248.png"> &nbsp; &nbsp; &nbsp; <img width="251" alt="image" src="https://user-images.githubusercontent.com/77919345/161322631-643f71be-7d06-476b-9a45-c4fb770531e1.png">



